### PR TITLE
refactor: remove cocoapods ruby patch

### DIFF
--- a/Formula/cocoapods.rb
+++ b/Formula/cocoapods.rb
@@ -4,12 +4,20 @@ class Cocoapods < Formula
   url "https://github.com/CocoaPods/CocoaPods/archive/1.12.1.tar.gz"
   sha256 "da018fc61694753ecb7ac33b21215fd6fb2ba660bd7d6c56245891de1a5f061c"
   license "MIT"
-  revision 2
+
+  bottle do
+    sha256 cellar: :any,                 arm64_ventura:  "6f1fca1cb0df79912e10743a80522e666fe605a1eaa2aac1094c501608fb7ee4"
+    sha256 cellar: :any,                 arm64_monterey: "8f7eff899cc1807286374e29e634c1008e286c3360df6cbcb90e27b0fe5567a9"
+    sha256 cellar: :any,                 arm64_big_sur:  "346833fef239df933ddb67341c55c9c4a7e547fc03afdc332861ac2ae8ba3372"
+    sha256 cellar: :any,                 ventura:        "b114ec0a11a2e472026f0f7337d17558bead2ac1122d9c2bb9278fc6b31fd744"
+    sha256 cellar: :any,                 monterey:       "946f0282afe0000ba9e23f30ce2175bc4b1f0c6d7e27145f01be4665b9786f8a"
+    sha256 cellar: :any,                 big_sur:        "1fe6f0c45e0c13e122aa1d8bf1f9bd9496fa3bb00fe7bc19286425e029e5c278"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e297731632b715118c13688acff976ce56c49df705ba2ae616445fb68cb49152"
+  end
 
   depends_on "pkg-config" => :build
   depends_on "ruby"
   uses_from_macos "libffi", since: :catalina
-
 
   def install
     if MacOS.version >= :mojave && MacOS::CLT.installed?

--- a/Formula/cocoapods.rb
+++ b/Formula/cocoapods.rb
@@ -10,11 +10,6 @@ class Cocoapods < Formula
   depends_on "ruby"
   uses_from_macos "libffi", since: :catalina
 
-  # Fix compatibility with Ruby 3.2, remove in next release
-  patch do
-    url "https://github.com/CocoaPods/CocoaPods/commit/2af8ba7e3477296d975243eeb1c12f379ab556a1.patch?full_index=1"
-    sha256 "391da12230d5e413853d96af7f310f5e588e80974df82caf1284c3d6f467cabc"
-  end
 
   def install
     if MacOS.version >= :mojave && MacOS::CLT.installed?


### PR DESCRIPTION
Installation went through this time.

```
brew install Formula/cocoapods.rb 
Running `brew update --auto-update`...
==> Auto-updated Homebrew!
==> Updated Homebrew from f7b322557 to 4.0.19 (33ab8e755).
Updated 2 taps (homebrew/core and homebrew/cask).
==> New Formulae
ast-grep           clive              libmediainfo       mods               rojo               yamlfmt
boolector          libabigail         libzen             roblox-ts          rye
==> New Casks
smooze-pro

You have 28 outdated formulae installed.


The 4.0.0 release notes are available on the Homebrew Blog:
  https://brew.sh/blog/4.0.0
The 4.0.19 changelog can be found at:
  https://github.com/Homebrew/brew/releases/tag/4.0.19
Error: Failed to load cask: Formula/cocoapods.rb
Cask 'cocoapods' is unreadable: wrong constant name #<Class:0x0000000138619f70>
Warning: Treating Formula/cocoapods.rb as a formula.
cocoapods 1.12.1 is already installed but outdated (so it will be upgraded).
==> Fetching cocoapods
==> Downloading https://github.com/CocoaPods/CocoaPods/archive/1.12.1.tar.gz
==> Downloading from https://codeload.github.com/CocoaPods/CocoaPods/tar.gz/refs/tags/1.12.1
##  #                                                                                      -=O=-                  
==> Upgrading cocoapods
  1.12.1 -> 1.12.1_2 

==> gem build cocoapods.gemspec
==> gem install cocoapods-1.12.1.gem
🍺  /opt/homebrew/Cellar/cocoapods/1.12.1_2: 13,431 files, 27.8MB, built in 42 seconds
==> Running `brew cleanup cocoapods`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /opt/homebrew/Cellar/cocoapods/1.12.1... (13,430 files, 27.8MB)
```